### PR TITLE
disable expansion in drawtext statements

### DIFF
--- a/captions/vtt2xmeml
+++ b/captions/vtt2xmeml
@@ -47,7 +47,7 @@ while read LINE ; do
                 ADJUSTED_LINE=$(echo "$SUBTITLE_LINE" | perl -MHTML::Entities -pe 'decode_entities($_);' | sed -e 's/<[^>]*>//g')
                 echo "${ADJUSTED_LINE}"
                 echo "${ADJUSTED_LINE}" > "/tmp/subtitle_${n}.txt"
-                DRAWTEXT_LINE+=",drawtext=fontfile=${FONTFILE}:textfile=/tmp/subtitle_${n}.txt:fontcolor=${FONTCOLOR}:bordercolor=${BORDERCOLOR}:borderw=${BORDERW}:fontsize=${FONTSIZE}:x=(w-text_w)/2:y=h*0.$LINE+$FONTSIZE*$n"
+                DRAWTEXT_LINE+=",drawtext=expansion=none:fontfile=${FONTFILE}:textfile=/tmp/subtitle_${n}.txt:fontcolor=${FONTCOLOR}:bordercolor=${BORDERCOLOR}:borderw=${BORDERW}:fontsize=${FONTSIZE}:x=(w-text_w)/2:y=h*0.$LINE+$FONTSIZE*$n"
             fi
             ((n++))
             unset SUBTITLE


### PR DESCRIPTION
fixes an issue when the line includes a `%`